### PR TITLE
add func args to __exit__ of NpDataclassReader

### DIFF
--- a/bionumpy/files.py
+++ b/bionumpy/files.py
@@ -20,7 +20,7 @@ class NpDataclassReader:
     def __enter__(self):
         return self
 
-    def __exit__(self):
+    def __exit__(self, exc_type, exc_value, traceback):
         self._reader.close()
 
     def read(self):


### PR DESCRIPTION
when using "with" to open a file, if an exception occurs in the following block, currently the code breaks because of missing func args in __exit__ instead of the true error (some more fancy exception handling might be needed here due to generators, but this should fix the error message)